### PR TITLE
Rely on relative paths for checking out additional packages

### DIFF
--- a/Makefile.freebsd
+++ b/Makefile.freebsd
@@ -3,17 +3,20 @@
 #
 export AUTO_GOPATH=1
 export DEST_DIR=$(PWD)/bundles/bin
-export RUNC_PATH="$(GOPATH)/src/github.com/opencontainers/runc"
-export CONTAINERD_PATH="$(GOPATH)/src/github.com/containerd/containerd"
-export LIBNETWORK_PATH="$(GOPATH)/src/github.com/docker/libnetwork"
-export TINI_PATH="$(GOPATH)/tini"
+export RUNC_PATH="../../opencontainers/runc"
+export CONTAINERD_PATH="../../containerd/containerd"
+export LIBNETWORK_PATH="../libnetwork"
+export TINI_PATH="../../../tini"
+
+CONTAINERD_REFSPEC=freebsd-compat-0.2
 
 binary: $(DEST_DIR)/docker-containerd $(DEST_DIR)/docker-proxy
 	./hack/make.sh binary
 
 $(DEST_DIR)/docker-containerd: prepare
 	if [ ! -d $(CONTAINERD_PATH) ]; then \
-		git clone https://github.com/freebsd-docker/containerd.git $(CONTAINERD_PATH); \
+		git clone https://github.com/freebsd-docker/containerd.git $(CONTAINERD_PATH) && \
+		git checkout $(CONTAINERD_REFSPEC); \
 	fi;
 	cd $(CONTAINERD_PATH) && \
 		$(MAKE) && \


### PR DESCRIPTION
$GOPATH can't be trusted not to have colons in it, and $GOROOT cannot be trusted
to be user writeable. Therefore we'll just rely on the conventional nature of
go packages
