### PR TITLE
Continue FreeBSD WIP

### DIFF
--- a/daemon/daemon_freebsd.go
+++ b/daemon/daemon_freebsd.go
@@ -35,3 +35,11 @@ func (daemon *Daemon) stats(c *container.Container) (*types.StatsJSON, error) {
 func (daemon *Daemon) initCgroupsPath(path string) error {
     return nil
 }
+
+func (daemon *Daemon) setupSeccompProfile() error {
+	return nil
+}
+
+func setupDaemonProcess(config *config.Config) error {
+	return nil
+}

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -36,7 +36,6 @@ import (
 	"github.com/docker/libnetwork/netlabel"
 	"github.com/docker/libnetwork/options"
 	"github.com/opencontainers/runc/libcontainer/label"
-	rsystem "github.com/opencontainers/runc/libcontainer/system"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
 
@@ -1021,33 +1020,6 @@ func rootFSToAPIType(rootfs *image.RootFS) types.RootFS {
 	}
 }
 
-// setupDaemonProcess sets various settings for the daemon's process
-func setupDaemonProcess(config *config.Config) error {
-	// setup the daemons oom_score_adj
-	return setupOOMScoreAdj(config.OOMScoreAdjust)
-}
-
-func setupOOMScoreAdj(score int) error {
-	f, err := os.OpenFile("/proc/self/oom_score_adj", os.O_WRONLY, 0)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-	stringScore := strconv.Itoa(score)
-	_, err = f.WriteString(stringScore)
-	if os.IsPermission(err) {
-		// Setting oom_score_adj does not work in an
-		// unprivileged container. Ignore the error, but log
-		// it if we appear not to be in that situation.
-		if !rsystem.RunningInUserNS() {
-			logrus.Debugf("Permission denied writing %q to /proc/self/oom_score_adj", stringScore)
-		}
-		return nil
-	}
-
-	return err
-}
-
 func maybeCreateCPURealTimeFile(sysinfoPresent bool, configValue int64, file string, path string) error {
 	if sysinfoPresent && configValue != 0 {
 		if err := os.MkdirAll(path, 0755); err != nil && !os.IsExist(err) {
@@ -1060,14 +1032,3 @@ func maybeCreateCPURealTimeFile(sysinfoPresent bool, configValue int64, file str
 	return nil
 }
 
-func (daemon *Daemon) setupSeccompProfile() error {
-	if daemon.configStore.SeccompProfile != "" {
-		daemon.seccompProfilePath = daemon.configStore.SeccompProfile
-		b, err := ioutil.ReadFile(daemon.configStore.SeccompProfile)
-		if err != nil {
-			return fmt.Errorf("opening seccomp profile (%s) failed: %v", daemon.configStore.SeccompProfile, err)
-		}
-		daemon.seccompProfile = b
-	}
-	return nil
-}

--- a/pkg/parsers/operatingsystem/operatingsystem_freebsd.go
+++ b/pkg/parsers/operatingsystem/operatingsystem_freebsd.go
@@ -1,10 +1,11 @@
-// +build darwin
+// +build freebsd
 
 package operatingsystem
 
 import (
 	"errors"
 	"os/exec"
+	"syscall"
 )
 
 // GetOperatingSystem gets the name of the current operating system.
@@ -18,7 +19,13 @@ func GetOperatingSystem() (string, error) {
 }
 
 // IsContainerized returns true if we are running inside a container.
-// No-op on FreeBSD and Darwin, always returns false.
 func IsContainerized() (bool, error) {
-	return false, errors.New("Cannot detect if we are in container")
+	jailed, err := syscall.Sysctl("security.jail.jailed")
+	if err != nil {
+		return false, errors.New("Cannot detect if we are in a jail")
+	}
+	if jailed[0] == 1 {
+		return true, nil
+	}
+	return false, nil
 }


### PR DESCRIPTION
* Implement jail detection
* move Linuxisms from `daemon/daemon_unix.go` to `daemon/daemon_linux.go`, as both Seccomp and OOM Score adjusting aren't UNIX universals.